### PR TITLE
Improve experience for iOS

### DIFF
--- a/app/helpers/getMobileOperatingSystem.ts
+++ b/app/helpers/getMobileOperatingSystem.ts
@@ -1,0 +1,24 @@
+// https://stackoverflow.com/questions/53666113/
+
+export function getMobileOperatingSystem() {
+  // @ts-ignore window.opera
+  var userAgent = navigator.userAgent || navigator.vendor || window.opera;
+
+  // Windows Phone must come first because its UA also contains "Android"
+  if (/windows phone/i.test(userAgent)) {
+    return "Windows Phone";
+  }
+
+  if (/android/i.test(userAgent)) {
+    return "Android";
+  }
+
+  // iOS detection from: https://stackoverflow.com/questions/9038625/
+  let isIOS = /iPad|iPhone|iPod/.test(navigator.platform)
+    || (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)
+  if (isIOS) {
+    return "iOS";
+  }
+
+  return "unknown";
+}

--- a/docs/README-localdev.md
+++ b/docs/README-localdev.md
@@ -1,9 +1,47 @@
 # Happy Island Designer - Local Development Guide
 
-`git clone https://github.com/eugeneration/HappyIslandDesigner.git`
+### First time Setup
 
-`cd HappyIslandDesigner`
+Install Dependencies:
+- Node
+- Yarn
 
-`python -m http.server`
+Fork the Happy Island Designer repo on GitHub.
+
+```
+git clone https://github.com/[your username]/HappyIslandDesigner.git`
+cd HappyIslandDesigner
+yarn
+yarn upgrade paper
+```
+**Note**: you will probably need to run `yarn upgrade paper` every time you change package.json. I don't know how to fix this yet.
+
+### Development
+```
+yarn dev
+```
+
+In your web browser, go to http://localhost:8080/. This will rebuild and hot-reload automatically as you make changes.
+
+
+### Test build
+```
+yarn build
+python -m http.server
+```
+In your web browser, go to http://localhost:8000/
+
+### Deploy
+Create a Pull Request to your repo/branch.
+
+
+## Other tips
+### Testing relative routes
+Sometimes webpack can get a little finicky when it comes to relative routes in .scss or .html files. To make sure your relative routes are working, run a server where the HappyIslandDesigner directory is not the root.
+
+```
+cd HappyIslandDesigner
+python -m http.server
+```
 
 In your web browser, go to http://localhost:8000/

--- a/yarn.lock
+++ b/yarn.lock
@@ -5215,7 +5215,7 @@ paper-animate@1.2.1:
 
 paper@eugeneration/paper.js#develop:
   version "0.12.4"
-  resolved "https://codeload.github.com/eugeneration/paper.js/tar.gz/ea16dc486330511a743e20c178a1e0f542ad8e18"
+  resolved "https://codeload.github.com/eugeneration/paper.js/tar.gz/3fcb6d515a57f79e600344812e52f24fb1175e54"
 
 parallel-transform@^1.1.0:
   version "1.2.0"


### PR DESCRIPTION
- iPad user agent was changed in ios 13, need to add an additional check to determine that it is a mobile device. Without this check, touch events were being duplicated, causing the menus to open and then close immediately
- save did not work on iOS Safari. This is because they disallow JS from downloading files. I have to open a new tab with the datauri and have the user save the image from the new tab.