### PR TITLE
ios make loading work

### DIFF
--- a/app/load.ts
+++ b/app/load.ts
@@ -105,9 +105,14 @@ export function loadImage(onLoad) {
 
 export function loadFile(onLoad) {
   const fileInput = document.createElement('input');
+  document.body.appendChild(fileInput);
   fileInput.type = 'file';
+  fileInput.accept="image/*";
   fileInput.style.display = 'none';
-  fileInput.onchange = onLoad;
+  fileInput.onchange = (event) => {
+    onLoad(event);
+    fileInput.remove();
+  }
   clickElem(fileInput);
 }
 


### PR DESCRIPTION
Turns out for safari, the file <input> tag needs to be part of the DOM in order for the file to properly load. How many gotchas will Safari lay on me?